### PR TITLE
Ignore all informations before the json start tag

### DIFF
--- a/src/bake/IncsAndDefsExecutor.ts
+++ b/src/bake/IncsAndDefsExecutor.ts
@@ -58,6 +58,7 @@ class IncsAndDefsExecutor {
     }
 
     private parseOutput(output: string): Promise<IncludesAndDefines> {
+        output = output.substring(output.search("{"), output.length);
         return new Promise((resolve, reject) => {
             try {
                 const bakeOutputAsObj = JSON.parse(output);


### PR DESCRIPTION
Since bake version 2.47.0 the call "bake --incs-and-defs=json" generates additional informations in the json output file. This causes the json parser to crash if the file is read, because these additional informations are not a valid json format. Ignore all additionl informations till the json start tag.